### PR TITLE
Dependency to service-proxy-core is mandatory.

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -31,6 +31,10 @@
 			<artifactId>com.predic8.membrane.osgi</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.membrane-soa.service-proxy</groupId>
+			<artifactId>service-proxy-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.5</version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
 				<artifactId>com.predic8.plugin.membrane</artifactId>
 				<version>${project.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>org.membrane-soa.service-proxy</groupId>
+				<artifactId>service-proxy-core</artifactId>
+				<version>4.0.13-SNAPSHOT</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
Ohne service-proxy-core nicht kompilierbar.
